### PR TITLE
brand null false 1030

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ belongs_to :user
 |name|string|null:false|
 |introduction|text|null:false|
 |price|integer|null:false|
-|brand|text|null:false|
+|brand|text|
 |item_condition_id(acitve_hash)|integer|null:false|
 |postage_payer_id(acitve_hash)|integer|null:false|
 |prefecture_code_id(acitve_hash)|integer|null:false|


### PR DESCRIPTION
# what
フリマアプリ 提出の修正

# why
商品出品の ブランドは 任意なので
README の items の brabd の null:false を削除